### PR TITLE
WI00697921 - NCN - Removing last node from Workflow Relationship Designer throws exception

### DIFF
--- a/src/Blazor.Diagrams/Components/DiagramCanvas.razor.cs
+++ b/src/Blazor.Diagrams/Components/DiagramCanvas.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.JSInterop;
 
 namespace Blazor.Diagrams.Components;
 
-public partial class DiagramCanvas : IDisposable
+public partial class DiagramCanvas : IAsyncDisposable
 {
     private DotNetObjectReference<DiagramCanvas>? _reference;
     private bool _shouldRender;
@@ -28,7 +28,7 @@ public partial class DiagramCanvas : IDisposable
 
     [Inject] public IJSRuntime JSRuntime { get; set; } = null!;
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         BlazorDiagram.Changed -= OnDiagramChanged;
 
@@ -36,7 +36,7 @@ public partial class DiagramCanvas : IDisposable
             return;
 
         if (elementReference.Id != null)
-            _ = JSRuntime.UnobserveResizes(elementReference);
+            await JSRuntime.UnobserveResizes(elementReference);
 
         _reference.Dispose();
     }

--- a/tests/Blazor.Diagrams.Tests/Components/DiagramCanvasTests.cs
+++ b/tests/Blazor.Diagrams.Tests/Components/DiagramCanvasTests.cs
@@ -1,0 +1,28 @@
+﻿using Blazor.Diagrams.Components;
+using Blazor.Diagrams.Core.Geometry;
+using Bunit;
+using Xunit;
+
+namespace Blazor.Diagrams.Tests.Components
+{
+    public class DiagramCanvasTests
+    {
+        [Fact]
+        public void Behavior_WhenDisposing_ShouldUnsubscribeToResizes()
+        {
+            // Arrange
+            JSRuntimeInvocationHandler call;
+            using (var ctx = new TestContext())
+            {
+                ctx.JSInterop.Setup<Rectangle>("ZBlazorDiagrams.getBoundingClientRect", _ => true);
+                call = ctx.JSInterop.SetupVoid("ZBlazorDiagrams.unobserve", _ => true).SetVoidResult();
+
+                // Act
+                var cut = ctx.RenderComponent<DiagramCanvas>(p => p.Add(n => n.BlazorDiagram, new BlazorDiagram()));
+            }
+
+            // Assert
+            call.VerifyInvoke("ZBlazorDiagrams.unobserve", calledTimes: 1);
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR changes DiagramCanvas to await the unsubscription to Resizes subscription, avoiding reference errors caused by race conditions.