### PR TITLE
resizing issue when resize to minimal dimension with resizer other than right-bottom resizer

### DIFF
--- a/src/Blazor.Diagrams.Core/Positions/Resizing/ResizerProvider.cs
+++ b/src/Blazor.Diagrams.Core/Positions/Resizing/ResizerProvider.cs
@@ -41,12 +41,20 @@ namespace Blazor.Diagrams.Core.Positions.Resizing
             if (width < NodeModel!.MinimumDimensions.Width)
             {
                 width = NodeModel.MinimumDimensions.Width;
-                positionX = NodeModel.Position.X;
+
+                if (ShouldChangeXPositionOnResize)
+                {
+                    positionX = OriginalPosition.X + OriginalSize.Width - NodeModel.MinimumDimensions.Width;
+                }
             }
             if (height < NodeModel.MinimumDimensions.Height)
             {
                 height = NodeModel.MinimumDimensions.Height;
-                positionY = NodeModel.Position.Y;
+
+                if (ShouldChangeYPositionOnResize)
+                {
+                    positionY = OriginalPosition.Y + OriginalSize.Height - NodeModel.MinimumDimensions.Height;
+                }
             }
 
             return (new Size(width, height), new Point(positionX, positionY));

--- a/tests/Blazor.Diagrams.Core.Tests/Positions/Resizing/BottomLeftResizerProviderTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Positions/Resizing/BottomLeftResizerProviderTests.cs
@@ -81,7 +81,8 @@ public class BottomLeftResizerProviderTests
         var diagram = new TestDiagram();
         diagram.SetContainer(new Rectangle(0, 0, 1000, 400));
         var node = new NodeModel(position: new Point(0, 0));
-        node.Size = new Size(100, 200);
+        node.Size = new Size(300, 300);
+        node.MinimumDimensions = new Size(50, 100);
         var control = new ResizeControl(new BottomLeftResizerProvider());
         diagram.Controls.AddFor(node).Add(control);
         diagram.SelectModel(node, false);
@@ -89,22 +90,22 @@ public class BottomLeftResizerProviderTests
         // before resize
         node.Position.X.Should().Be(0);
         node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        node.Size.Width.Should().Be(300);
+        node.Size.Height.Should().Be(300);
 
         // resize
-        var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
+        var eventArgs = new PointerEventArgs(0, 300, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
         control.OnPointerDown(diagram, node, eventArgs);
-        eventArgs = new PointerEventArgs(99, -199, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
+        eventArgs = new PointerEventArgs(150, 150, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
         diagram.TriggerPointerMove(null, eventArgs);
-        eventArgs = new PointerEventArgs(300, -300, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
+        eventArgs = new PointerEventArgs(400, -100, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(99);
+        node.Position.X.Should().Be(250);
         node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(0);
-        node.Size.Height.Should().Be(0);
+        node.Size.Width.Should().Be(50);
+        node.Size.Height.Should().Be(100);
     }
 
     [Fact]

--- a/tests/Blazor.Diagrams.Core.Tests/Positions/Resizing/TopLeftResizerProviderTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Positions/Resizing/TopLeftResizerProviderTests.cs
@@ -82,7 +82,8 @@ public class TopLeftResizerProviderTests
         var diagram = new TestDiagram();
         diagram.SetContainer(new Rectangle(0, 0, 1000, 400));
         var node = new NodeModel(position: new Point(0, 0));
-        node.Size = new Size(100, 200);
+        node.Size = new Size(300, 300);
+        node.MinimumDimensions = new Size(50, 100);
         var control = new ResizeControl(new TopLeftResizerProvider());
         diagram.Controls.AddFor(node).Add(control);
         diagram.SelectModel(node, false);
@@ -90,22 +91,22 @@ public class TopLeftResizerProviderTests
         // before resize
         node.Position.X.Should().Be(0);
         node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        node.Size.Width.Should().Be(300);
+        node.Size.Height.Should().Be(300);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
         control.OnPointerDown(diagram, node, eventArgs);
-        eventArgs = new PointerEventArgs(99, 199, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
+        eventArgs = new PointerEventArgs(150, 150, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
         diagram.TriggerPointerMove(null, eventArgs);
-        eventArgs = new PointerEventArgs(300, 300, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
+        eventArgs = new PointerEventArgs(400, 400, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(99);
-        node.Position.Y.Should().Be(199);
-        node.Size.Width.Should().Be(0);
-        node.Size.Height.Should().Be(0);
+        node.Position.X.Should().Be(250);
+        node.Position.Y.Should().Be(200);
+        node.Size.Width.Should().Be(50);
+        node.Size.Height.Should().Be(100);
     }
 
     [Fact]

--- a/tests/Blazor.Diagrams.Core.Tests/Positions/Resizing/TopRightResizerProviderTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Positions/Resizing/TopRightResizerProviderTests.cs
@@ -80,7 +80,8 @@ public class TopRightResizerProviderTests
         var diagram = new TestDiagram();
         diagram.SetContainer(new Rectangle(0, 0, 1000, 400));
         var node = new NodeModel(position: new Point(0, 0));
-        node.Size = new Size(100, 200);
+        node.Size = new Size(300, 300);
+        node.MinimumDimensions = new Size(50, 100);
         var control = new ResizeControl(new TopRightResizerProvider());
         diagram.Controls.AddFor(node).Add(control);
         diagram.SelectModel(node, false);
@@ -88,22 +89,22 @@ public class TopRightResizerProviderTests
         // before resize
         node.Position.X.Should().Be(0);
         node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        node.Size.Width.Should().Be(300);
+        node.Size.Height.Should().Be(300);
 
         // resize
-        var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
+        var eventArgs = new PointerEventArgs(300, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
         control.OnPointerDown(diagram, node, eventArgs);
-        eventArgs = new PointerEventArgs(-99, 199, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
+        eventArgs = new PointerEventArgs(150, 150, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
         diagram.TriggerPointerMove(null, eventArgs);
-        eventArgs = new PointerEventArgs(-300, 300, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
+        eventArgs = new PointerEventArgs(-100, 400, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
         node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(199);
-        node.Size.Width.Should().Be(0);
-        node.Size.Height.Should().Be(0);
+        node.Position.Y.Should().Be(200);
+        node.Size.Width.Should().Be(50);
+        node.Size.Height.Should().Be(100);
     }
 
     [Fact]


### PR DESCRIPTION
Changes to current unit tests:
1. Instead of testing on a minimal dimension of (0, 0), now testing on a size that's bigger than 0.
2. The calculation of position when node is at minimal dimension was not quite correct, now is expecting the right position.