### PR TITLE
WI00745224 - JavaScript interop calls cannot be issued at this time

### DIFF
--- a/src/Blazor.Diagrams/Components/DiagramCanvas.razor.cs
+++ b/src/Blazor.Diagrams/Components/DiagramCanvas.razor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Blazor.Diagrams.Core.Behaviors;
+﻿using Blazor.Diagrams.Core.Behaviors;
 using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Extensions;
 using Microsoft.AspNetCore.Components;
@@ -40,6 +38,9 @@ public partial class DiagramCanvas : IAsyncDisposable
             await JSRuntime.UnobserveResizes(elementReference);
 
         _reference.Dispose();
+        _reference = null!;
+
+        GC.SuppressFinalize(this); // CA1816
     }
 
     private string GetLayerStyle(int order)

--- a/src/Blazor.Diagrams/Extensions/JSRuntimeExtensions.cs
+++ b/src/Blazor.Diagrams/Extensions/JSRuntimeExtensions.cs
@@ -30,9 +30,9 @@ public static class JSRuntimeExtensions
         {
             await jsRuntime.InvokeVoidAsync("ZBlazorDiagrams.unobserve", element, element.Id);
         }
-        catch (ObjectDisposedException)
+        catch (JSDisconnectedException)
         {
-            // Ignore, DotNetObjectReference was likely disposed
+            // Ignore, JSRuntime was already disconnected
         }
     }
 

--- a/src/Blazor.Diagrams/Extensions/JSRuntimeExtensions.cs
+++ b/src/Blazor.Diagrams/Extensions/JSRuntimeExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Blazor.Diagrams.Core.Geometry;
+﻿using Blazor.Diagrams.Core.Geometry;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 
@@ -28,7 +26,14 @@ public static class JSRuntimeExtensions
 
     public static async Task UnobserveResizes(this IJSRuntime jsRuntime, ElementReference element)
     {
-        await jsRuntime.InvokeVoidAsync("ZBlazorDiagrams.unobserve", element, element.Id);
+        try
+        {
+            await jsRuntime.InvokeVoidAsync("ZBlazorDiagrams.unobserve", element, element.Id);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Ignore, DotNetObjectReference was likely disposed
+        }
     }
 
     public static async Task AddDefaultPreventingForWheelHandler(this IJSRuntime jsRuntime, ElementReference element)


### PR DESCRIPTION
This PR changes the `JSRuntime` `UnobserveResizes` extension method to catch eventual `JSDisconnectedException` exceptions, which may occur when closing the page rendering the Diagram.

It also changes `DiagramCanvas.DisposeAsync` to address the warning of [CA1816](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1816) rule.