### PR TITLE
WI00856225 - Remove FluentAssertions from Blazor.Diagrams.Core.Tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Upload packages
       if: matrix.configuration == 'Release'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: package
         path: /home/runner/work/Blazor.Diagrams/Blazor.Diagrams/src/Blazor.Diagrams/bin/Release/*.nupkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,7 @@ jobs:
       with:
         dotnet-version: |
             8.0.x
-            7.0.x
             6.0.x
-            3.1.x
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
+            8.0.x
             6.0.x
             3.1.x
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
       with:
         dotnet-version: |
             8.0.x
+            7.0.x
             6.0.x
             3.1.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,9 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: |
+            8.0.x
+            6.0.x
 
       # Finds the latest release and increases the version
     - name: Get next version

--- a/src/Blazor.Diagrams.Core/Blazor.Diagrams.Core.csproj
+++ b/src/Blazor.Diagrams.Core/Blazor.Diagrams.Core.csproj
@@ -29,8 +29,8 @@
   </ItemGroup>
 
 <ItemGroup>
-    <PackageReference Include="SvgPathProperties" />
-    <PackageReference Include="Brutal.Dev.StrongNameSigner" PrivateAssets="All"/>
+  <PackageReference Include="SvgPathProperties" />
+  <PackageReference Include="Brutal.Dev.StrongNameSigner" PrivateAssets="All"/>
 </ItemGroup>
 
 </Project>

--- a/src/Blazor.Diagrams.Core/Blazor.Diagrams.Core.csproj
+++ b/src/Blazor.Diagrams.Core/Blazor.Diagrams.Core.csproj
@@ -28,9 +28,9 @@
     </None>
   </ItemGroup>
 
-	<ItemGroup>
-	  <PackageReference Include="SvgPathProperties" />
+  <ItemGroup>
+	<PackageReference Include="SvgPathProperties" />
     <PackageReference Include="Brutal.Dev.StrongNameSigner" PrivateAssets="All"/>
-	</ItemGroup>
+  </ItemGroup>
 
 </Project>

--- a/src/Blazor.Diagrams.Core/Blazor.Diagrams.Core.csproj
+++ b/src/Blazor.Diagrams.Core/Blazor.Diagrams.Core.csproj
@@ -28,9 +28,9 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-	<PackageReference Include="SvgPathProperties" />
+<ItemGroup>
+    <PackageReference Include="SvgPathProperties" />
     <PackageReference Include="Brutal.Dev.StrongNameSigner" PrivateAssets="All"/>
-  </ItemGroup>
+</ItemGroup>
 
 </Project>

--- a/src/Blazor.Diagrams/Blazor.Diagrams.csproj
+++ b/src/Blazor.Diagrams/Blazor.Diagrams.csproj
@@ -23,7 +23,6 @@
         <PackageReference Include="Brutal.Dev.StrongNameSigner" PrivateAssets="All" />
         <!-- Reference the SvgPathProperties that we already strong name signed -->
         <Reference Include="SvgPathProperties" PrivateAssets="All">
-          <HintPath>..\..\packages\svgpathproperties\1.1.2\lib\netstandard2.0\SvgPathProperties.dll</HintPath>
         </Reference>
     </ItemGroup>
 

--- a/src/Blazor.Diagrams/Blazor.Diagrams.csproj
+++ b/src/Blazor.Diagrams/Blazor.Diagrams.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
         <PackageReference Include="Brutal.Dev.StrongNameSigner" PrivateAssets="All" />
         <!-- Reference the SvgPathProperties that we already strong name signed -->
-		<PackageReference Include="SvgPathProperties" PrivateAssets="All" />
+        <PackageReference Include="SvgPathProperties" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Blazor.Diagrams/Blazor.Diagrams.csproj
+++ b/src/Blazor.Diagrams/Blazor.Diagrams.csproj
@@ -20,7 +20,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Components" />
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
-        <PacakgeReference Include="Brutal.Dev.StrongNameSigner" PrivateAssets="All" />
+        <PackageReference Include="Brutal.Dev.StrongNameSigner" PrivateAssets="All" />
         <!-- Reference the SvgPathProperties that we already strong name signed -->
         <Reference Include="SvgPathProperties" PrivateAssets="All">
           <HintPath>..\..\packages\svgpathproperties\1.1.2\lib\netstandard2.0\SvgPathProperties.dll</HintPath>

--- a/src/Blazor.Diagrams/Blazor.Diagrams.csproj
+++ b/src/Blazor.Diagrams/Blazor.Diagrams.csproj
@@ -22,8 +22,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
         <PackageReference Include="Brutal.Dev.StrongNameSigner" PrivateAssets="All" />
         <!-- Reference the SvgPathProperties that we already strong name signed -->
-		<PackageReference Include="SvgPathProperties" PrivateAssets="All">
-        </PackageReference>
+		<PackageReference Include="SvgPathProperties" PrivateAssets="All" />
 </ItemGroup>
 
     <ItemGroup>

--- a/src/Blazor.Diagrams/Blazor.Diagrams.csproj
+++ b/src/Blazor.Diagrams/Blazor.Diagrams.csproj
@@ -23,7 +23,7 @@
         <PackageReference Include="Brutal.Dev.StrongNameSigner" PrivateAssets="All" />
         <!-- Reference the SvgPathProperties that we already strong name signed -->
 		<PackageReference Include="SvgPathProperties" PrivateAssets="All" />
-</ItemGroup>
+    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Blazor.Diagrams.Core\Blazor.Diagrams.Core.csproj" PrivateAssets="All"/>

--- a/src/Blazor.Diagrams/Blazor.Diagrams.csproj
+++ b/src/Blazor.Diagrams/Blazor.Diagrams.csproj
@@ -22,9 +22,9 @@
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
         <PackageReference Include="Brutal.Dev.StrongNameSigner" PrivateAssets="All" />
         <!-- Reference the SvgPathProperties that we already strong name signed -->
-        <Reference Include="SvgPathProperties" PrivateAssets="All">
-        </Reference>
-    </ItemGroup>
+		<PackageReference Include="SvgPathProperties" PrivateAssets="All">
+        </PackageReference>
+</ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Blazor.Diagrams.Core\Blazor.Diagrams.Core.csproj" PrivateAssets="All"/>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>

--- a/tests/Blazor.Diagrams.Core.Tests/Anchors/DynamicAnchorTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Anchors/DynamicAnchorTests.cs
@@ -2,7 +2,6 @@
 using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Core.Models;
 using Blazor.Diagrams.Core.Positions;
-using FluentAssertions;
 using Xunit;
 
 namespace Blazor.Diagrams.Core.Tests.Anchors;
@@ -37,7 +36,7 @@ public class DynamicAnchorTests
         var position = anchor1.GetPosition(link);
 
         // Assert
-        position.Should().BeNull();
+        Assert.Null(position);
     }
 
     [Fact]
@@ -72,9 +71,9 @@ public class DynamicAnchorTests
         var position = anchor1.GetPosition(link);
 
         // Assert
-        position.Should().NotBeNull();
-        position!.X.Should().Be(220);
-        position.Y.Should().Be(95);
+        Assert.NotNull(position);
+        Assert.Equal(220,position!.X);
+        Assert.Equal(95, position.Y);
     }
 
     [Fact]
@@ -109,9 +108,9 @@ public class DynamicAnchorTests
         var position = anchor1.GetPosition(link);
 
         // Assert
-        position.Should().NotBeNull();
-        position!.X.Should().Be(230);
-        position.Y.Should().Be(85);
+        Assert.NotNull(position);
+        Assert.Equal(230, position!.X);
+        Assert.Equal(85, position.Y);
     }
 
     [Fact]
@@ -149,9 +148,9 @@ public class DynamicAnchorTests
         });
 
         // Assert
-        position.Should().NotBeNull();
-        position!.X.Should().Be(220);
-        position.Y.Should().Be(125);
+        Assert.NotNull(position);
+        Assert.Equal(220, position!.X);
+        Assert.Equal(125, position.Y);
     }
 
     [Fact]
@@ -189,8 +188,8 @@ public class DynamicAnchorTests
         });
 
         // Assert
-        position.Should().NotBeNull();
-        position!.X.Should().Be(300);
-        position.Y.Should().Be(120);
+        Assert.NotNull(position);
+        Assert.Equal(300, position!.X);
+        Assert.Equal(120, position.Y);
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Anchors/ShapeIntersectionAnchorTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Anchors/ShapeIntersectionAnchorTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Blazor.Diagrams.Core.Anchors;
 using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Core.Models;
-using FluentAssertions;
 using Moq;
 using Xunit;
 
@@ -27,8 +26,8 @@ public class ShapeIntersectionAnchorTests
 
         // Assert
         var center = node.GetBounds()!.Center;
-        position.X.Should().Be(center.X);
-        position.Y.Should().Be(center.Y);
+        Assert.Equal(center.X, position.X);
+        Assert.Equal(center.Y, position.Y);
     }
 
     [Fact]
@@ -43,7 +42,7 @@ public class ShapeIntersectionAnchorTests
         var position = anchor.GetPosition(link);
 
         // Assert
-        position.Should().BeNull();
+        Assert.Null(position);
     }
 
     [Fact]
@@ -67,8 +66,8 @@ public class ShapeIntersectionAnchorTests
 
         // Assert
         var line = args.Single();
-        line.Start.Should().BeEquivalentTo(route[0]);
-        line.End.Should().BeEquivalentTo(node.GetBounds()!.Center);
+        Assert.Equal(route[0],line.Start);
+        Assert.Equal(node.GetBounds()!.Center, line.End);
     }
 
     [Fact]
@@ -93,8 +92,8 @@ public class ShapeIntersectionAnchorTests
 
         // Assert
         var line = args.Single();
-        line.Start.Should().BeEquivalentTo(route[^1]);
-        line.End.Should().BeEquivalentTo(node.GetBounds()!.Center);
+        Assert.Equal(route[^1],line.Start);
+        Assert.Equal(node.GetBounds()!.Center,line.End);
     }
 
     [Fact]
@@ -120,8 +119,8 @@ public class ShapeIntersectionAnchorTests
 
         // Assert
         var line = args.Single();
-        line.Start.Should().BeEquivalentTo(pt);
-        line.End.Should().BeEquivalentTo(node.GetBounds()!.Center);
+        Assert.Equal(pt,line.Start);
+        Assert.Equal(node.GetBounds()!.Center, line.End);
     }
 
     [Fact]
@@ -145,7 +144,7 @@ public class ShapeIntersectionAnchorTests
         var position = source.GetPosition(link);
 
         // Assert
-        position.Should().BeNull();
+        Assert.Null(position);
     }
 
     private class CustomNodeModel : NodeModel

--- a/tests/Blazor.Diagrams.Core.Tests/Anchors/SinglePortAnchorTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Anchors/SinglePortAnchorTests.cs
@@ -1,7 +1,6 @@
 using Blazor.Diagrams.Core.Anchors;
 using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Core.Models;
-using FluentAssertions;
 using Moq;
 using Xunit;
 
@@ -26,8 +25,8 @@ public class SinglePortAnchorTests
 
         // Assert
         var mp = port.MiddlePosition;
-        position.X.Should().Be(mp.X);
-        position.Y.Should().Be(mp.Y);
+        Assert.Equal(mp.X, position.X);
+        Assert.Equal(mp.Y, position.Y);
     }
 
     [Fact]
@@ -47,7 +46,7 @@ public class SinglePortAnchorTests
         var position = anchor.GetPosition(link);
 
         // Assert
-        position.Should().BeNull();
+        Assert.Null(position);
     }
 
     [Fact]
@@ -72,8 +71,8 @@ public class SinglePortAnchorTests
 
         // Assert
         var mp = port.MiddlePosition;
-        position.X.Should().Be(mp.X);
-        position.Y.Should().Be(mp.Y);
+        Assert.Equal(mp.X, position.X);
+        Assert.Equal(mp.Y, position.Y);
     }
 
     [Theory]
@@ -106,8 +105,8 @@ public class SinglePortAnchorTests
         var position = anchor.GetPosition(link)!;
 
         // Assert
-        position.X.Should().Be(x);
-        position.Y.Should().Be(y);
+        Assert.Equal(x, position.X);
+        Assert.Equal(y, position.Y);    
     }
 
     [Theory]

--- a/tests/Blazor.Diagrams.Core.Tests/Anchors/SinglePortAnchorTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Anchors/SinglePortAnchorTests.cs
@@ -106,7 +106,7 @@ public class SinglePortAnchorTests
 
         // Assert
         Assert.Equal(x, position.X);
-        Assert.Equal(y, position.Y);    
+        Assert.Equal(y, position.Y);
     }
 
     [Theory]
@@ -138,7 +138,7 @@ public class SinglePortAnchorTests
 
         // Act
         var position = anchor.GetPosition(link)!;
-        
+
         // Assert
         shapeMock.Verify(s => s.GetPointAtAngle(angle), Times.Once);
     }

--- a/tests/Blazor.Diagrams.Core.Tests/Behaviors/DragMovablesBehaviorTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Behaviors/DragMovablesBehaviorTests.cs
@@ -3,7 +3,6 @@ using Blazor.Diagrams.Core.Events;
 using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Core.Models;
 using Blazor.Diagrams.Core.Options;
-using FluentAssertions;
 using Moq;
 using Xunit;
 
@@ -79,7 +78,7 @@ public class DragMovablesBehaviorTests
             new PointerEventArgs(150, 150, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
 
         // Assert
-        movedTrigger.Should().BeTrue();
+        Assert.True(movedTrigger);
     }
 
     [Fact]
@@ -99,7 +98,7 @@ public class DragMovablesBehaviorTests
             new PointerEventArgs(150, 150, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
 
         // Assert
-        movedTrigger.Should().BeFalse();
+        Assert.False(movedTrigger);
     }
 
     [Fact]

--- a/tests/Blazor.Diagrams.Core.Tests/Behaviors/DragNewLinkBehaviorTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Behaviors/DragNewLinkBehaviorTests.cs
@@ -3,7 +3,6 @@ using Blazor.Diagrams.Core.Behaviors;
 using Blazor.Diagrams.Core.Events;
 using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Core.Models;
-using FluentAssertions;
 using System.Linq;
 using Xunit;
 
@@ -32,11 +31,11 @@ public class DragNewLinkBehaviorTests
         // Assert
         var link = diagram.Links.Single();
         var source = link.Source as SinglePortAnchor;
-        source.Should().NotBeNull();
-        source!.Port.Should().BeSameAs(port);
+        Assert.NotNull(source);
+        Assert.Same(port, source!.Port);
         var ongoingPosition = (link.Target as PositionAnchor)!.GetPlainPosition()!;
-        ongoingPosition.X.Should().Be(100);
-        ongoingPosition.Y.Should().Be(100);
+        Assert.Equal(100, ongoingPosition.X);
+        Assert.Equal(100,ongoingPosition.Y);
     }
 
     [Fact]
@@ -64,14 +63,14 @@ public class DragNewLinkBehaviorTests
             new PointerEventArgs(100, 100, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
 
         // Assert
-        factoryCalled.Should().BeTrue();
+        Assert.True(factoryCalled);
         var link = diagram.Links.Single();
         var source = link.Source as SinglePortAnchor;
-        source.Should().NotBeNull();
-        source!.Port.Should().BeSameAs(port);
+        Assert.NotNull(source);
+        Assert.Same(port, source!.Port);
         var ongoingPosition = (link.Target as PositionAnchor)!.GetPlainPosition()!;
-        ongoingPosition.X.Should().Be(100);
-        ongoingPosition.Y.Should().Be(100);
+        Assert.Equal(100, ongoingPosition.X);
+        Assert.Equal(100,ongoingPosition.Y);
     }
 
     [Fact]
@@ -100,9 +99,9 @@ public class DragNewLinkBehaviorTests
         // Assert
         var source = link.Source as SinglePortAnchor;
         var ongoingPosition = (link.Target as PositionAnchor)!.GetPlainPosition()!;
-        ongoingPosition.X.Should().BeGreaterThan(145);
-        ongoingPosition.Y.Should().BeGreaterThan(145);
-        linkRefreshed.Should().BeTrue();
+        Assert.True(ongoingPosition.X > 145);
+        Assert.True(ongoingPosition.Y > 145);
+        Assert.True(linkRefreshed);
     }
 
     [Fact]
@@ -132,9 +131,9 @@ public class DragNewLinkBehaviorTests
         // Assert
         var source = link.Source as SinglePortAnchor;
         var ongoingPosition = (link.Target as PositionAnchor)!.GetPlainPosition()!;
-        ongoingPosition.X.Should().BeApproximately(107.7, 0.1);
-        ongoingPosition.Y.Should().BeApproximately(101.7, 0.1);
-        linkRefreshed.Should().BeTrue();
+        Assert.InRange(ongoingPosition.X, 107.6, 108.8); 
+        Assert.InRange(ongoingPosition.Y, 101.6, 101.8);
+        Assert.True(linkRefreshed);
     }
 
     [Fact]
@@ -172,9 +171,9 @@ public class DragNewLinkBehaviorTests
         // Assert
         var link = diagram.Links.Single();
         var target = link.Target as SinglePortAnchor;
-        target.Should().NotBeNull();
-        target!.Port.Should().BeSameAs(port2);
-        port2Refreshed.Should().BeTrue();
+        Assert.NotNull(target);
+        Assert.Same(port2, target!.Port);
+        Assert.True(port2Refreshed);
     }
 
     [Fact]
@@ -209,7 +208,7 @@ public class DragNewLinkBehaviorTests
 
         // Assert
         var link = diagram.Links.Single();
-        link.Target.Should().BeOfType<PositionAnchor>();
+        Assert.IsType<PositionAnchor>(link.Target);
     }
 
     [Fact]
@@ -251,8 +250,8 @@ public class DragNewLinkBehaviorTests
         // Assert
         var link = diagram.Links.Single();
         var target = link.Target as SinglePortAnchor;
-        target.Should().BeNull();
-        port2Refreshes.Should().Be(2);
+        Assert.Null(target);
+        Assert.Equal(2,port2Refreshes);
     }
 
     [Fact]
@@ -276,7 +275,7 @@ public class DragNewLinkBehaviorTests
             new PointerEventArgs(0, 0, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
 
         // Assert
-        diagram.Links.Should().BeEmpty();
+        Assert.Empty(diagram.Links);
     }
 
     [Fact]
@@ -300,7 +299,7 @@ public class DragNewLinkBehaviorTests
             new PointerEventArgs(0, 0, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
 
         // Assert
-        diagram.Links.Should().BeEmpty();
+        Assert.Empty(diagram.Links);
     }
 
     [Fact]
@@ -336,9 +335,9 @@ public class DragNewLinkBehaviorTests
         // Assert
         var link = diagram.Links.Single();
         var target = link.Target as SinglePortAnchor;
-        target.Should().NotBeNull();
-        target!.Port.Should().BeSameAs(port2);
-        port2Refreshes.Should().Be(1);
+        Assert.NotNull(target);                      
+        Assert.Same(port2, target!.Port);           
+        Assert.Equal(1, port2Refreshes);           
     }
 
     [Fact]
@@ -363,7 +362,7 @@ public class DragNewLinkBehaviorTests
             new PointerEventArgs(100, 100, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
 
         // Assert
-        diagram.Links.Should().HaveCount(0);
+        Assert.Empty(diagram.Links);
     }
 
     [Fact]
@@ -399,7 +398,7 @@ public class DragNewLinkBehaviorTests
             new PointerEventArgs(105, 105, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
 
         // Assert
-        targetAttachedTriggers.Should().Be(1);
+        Assert.Equal(1,targetAttachedTriggers);
     }
 
     [Fact]
@@ -440,7 +439,7 @@ public class DragNewLinkBehaviorTests
             new PointerEventArgs(140, 100, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
 
         // Assert
-        targetAttachedTriggers.Should().Be(1);
+        Assert.Equal(1, targetAttachedTriggers);
     }
 
     [Fact]
@@ -463,7 +462,7 @@ public class DragNewLinkBehaviorTests
             new PointerEventArgs(100, 100, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
 
         // Assert
-        diagram.Links.Count.Should().Be(0);
+        Assert.Equal(0, diagram.Links.Count);
     }
 
     [Fact]
@@ -494,8 +493,8 @@ public class DragNewLinkBehaviorTests
         // Assert
         var source = link.Source as SinglePortAnchor;
         var ongoingPosition = (link.Target as PositionAnchor)!.GetPlainPosition()!;
-        ongoingPosition.X.Should().BeApproximately(expectedValue: 246, 1);
-        ongoingPosition.Y.Should().BeApproximately(expectedValue: 246, 1);
-        linkRefreshed.Should().BeTrue();
+        Assert.InRange(ongoingPosition.X, 245, 247);   
+        Assert.InRange(ongoingPosition.Y, 245, 247);   
+        Assert.True(linkRefreshed);                    
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Behaviors/DragNewLinkBehaviorTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Behaviors/DragNewLinkBehaviorTests.cs
@@ -3,7 +3,6 @@ using Blazor.Diagrams.Core.Behaviors;
 using Blazor.Diagrams.Core.Events;
 using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Core.Models;
-using System.Linq;
 using Xunit;
 
 namespace Blazor.Diagrams.Core.Tests.Behaviors;
@@ -35,7 +34,7 @@ public class DragNewLinkBehaviorTests
         Assert.Same(port, source!.Port);
         var ongoingPosition = (link.Target as PositionAnchor)!.GetPlainPosition()!;
         Assert.Equal(100, ongoingPosition.X);
-        Assert.Equal(100,ongoingPosition.Y);
+        Assert.Equal(100, ongoingPosition.Y);
     }
 
     [Fact]
@@ -70,7 +69,7 @@ public class DragNewLinkBehaviorTests
         Assert.Same(port, source!.Port);
         var ongoingPosition = (link.Target as PositionAnchor)!.GetPlainPosition()!;
         Assert.Equal(100, ongoingPosition.X);
-        Assert.Equal(100,ongoingPosition.Y);
+        Assert.Equal(100, ongoingPosition.Y);
     }
 
     [Fact]
@@ -131,7 +130,7 @@ public class DragNewLinkBehaviorTests
         // Assert
         var source = link.Source as SinglePortAnchor;
         var ongoingPosition = (link.Target as PositionAnchor)!.GetPlainPosition()!;
-        Assert.InRange(ongoingPosition.X, 107.6, 108.8); 
+        Assert.InRange(ongoingPosition.X, 107.6, 107.8);
         Assert.InRange(ongoingPosition.Y, 101.6, 101.8);
         Assert.True(linkRefreshed);
     }
@@ -251,7 +250,7 @@ public class DragNewLinkBehaviorTests
         var link = diagram.Links.Single();
         var target = link.Target as SinglePortAnchor;
         Assert.Null(target);
-        Assert.Equal(2,port2Refreshes);
+        Assert.Equal(2, port2Refreshes);
     }
 
     [Fact]
@@ -335,9 +334,9 @@ public class DragNewLinkBehaviorTests
         // Assert
         var link = diagram.Links.Single();
         var target = link.Target as SinglePortAnchor;
-        Assert.NotNull(target);                      
-        Assert.Same(port2, target!.Port);           
-        Assert.Equal(1, port2Refreshes);           
+        Assert.NotNull(target);
+        Assert.Same(port2, target!.Port);
+        Assert.Equal(1, port2Refreshes);
     }
 
     [Fact]
@@ -398,7 +397,7 @@ public class DragNewLinkBehaviorTests
             new PointerEventArgs(105, 105, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
 
         // Assert
-        Assert.Equal(1,targetAttachedTriggers);
+        Assert.Equal(1, targetAttachedTriggers);
     }
 
     [Fact]
@@ -493,8 +492,8 @@ public class DragNewLinkBehaviorTests
         // Assert
         var source = link.Source as SinglePortAnchor;
         var ongoingPosition = (link.Target as PositionAnchor)!.GetPlainPosition()!;
-        Assert.InRange(ongoingPosition.X, 245, 247);   
-        Assert.InRange(ongoingPosition.Y, 245, 247);   
-        Assert.True(linkRefreshed);                    
+        Assert.InRange(ongoingPosition.X, 245, 247);
+        Assert.InRange(ongoingPosition.Y, 245, 247);
+        Assert.True(linkRefreshed);
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Behaviors/DragNewLinkBehaviorTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Behaviors/DragNewLinkBehaviorTests.cs
@@ -461,7 +461,7 @@ public class DragNewLinkBehaviorTests
             new PointerEventArgs(100, 100, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
 
         // Assert
-        Assert.Equal(0, diagram.Links.Count);
+        Assert.Empty(diagram.Links);
     }
 
     [Fact]

--- a/tests/Blazor.Diagrams.Core.Tests/Behaviors/EventsBehaviorTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Behaviors/EventsBehaviorTests.cs
@@ -1,6 +1,5 @@
 ﻿using Blazor.Diagrams.Core.Behaviors;
 using Blazor.Diagrams.Core.Events;
-using FluentAssertions;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -22,7 +21,7 @@ public class EventsBehaviorTests
         diagram.TriggerPointerUp(null, new PointerEventArgs(0, 0, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
 
         // Assert
-        eventTriggered.Should().BeFalse();
+        Assert.False(eventTriggered);
     }
 
     [Fact]
@@ -38,7 +37,7 @@ public class EventsBehaviorTests
         diagram.TriggerPointerUp(null, new PointerEventArgs(0, 0, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
 
         // Assert
-        eventTriggered.Should().BeTrue();
+        Assert.True(eventTriggered);
     }
 
     [Fact]
@@ -55,7 +54,7 @@ public class EventsBehaviorTests
         diagram.TriggerPointerUp(null, new PointerEventArgs(0, 0, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
 
         // Assert
-        eventTriggered.Should().BeFalse();
+        Assert.False(eventTriggered);
     }
 
     [Fact]
@@ -71,7 +70,7 @@ public class EventsBehaviorTests
         diagram.TriggerPointerClick(null, new PointerEventArgs(0, 0, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
 
         // Assert
-        eventTriggered.Should().BeTrue();
+        Assert.True(eventTriggered);
     }
 
     [Fact]
@@ -88,7 +87,7 @@ public class EventsBehaviorTests
         diagram.TriggerPointerClick(null, new PointerEventArgs(0, 0, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
 
         // Assert
-        eventTriggered.Should().BeFalse();
+        Assert.False(eventTriggered);
     }
 
     [Fact]
@@ -103,6 +102,6 @@ public class EventsBehaviorTests
         diagram.TriggerPointerUp(null, new PointerEventArgs(0, 0, 0, 0, false, false, false, 0, 0, 0, 0, 0, 0, string.Empty, true));
 
         // Assert
-        eventTriggered.Should().BeFalse();
+        Assert.False(eventTriggered);
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Behaviors/KeyboardShortcutsBehaviorTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Behaviors/KeyboardShortcutsBehaviorTests.cs
@@ -1,6 +1,5 @@
 ﻿using Blazor.Diagrams.Core.Behaviors;
 using Blazor.Diagrams.Core.Events;
-using FluentAssertions;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -33,7 +32,7 @@ public class KeyboardShortcutsBehaviorTests
         diagram.TriggerKeyDown(new KeyboardEventArgs(key, key, 0, ctrl, shift, alt));
 
         // Assert
-        executed.Should().BeTrue();
+        Assert.True(executed);
     }
 
     [Fact]
@@ -55,7 +54,7 @@ public class KeyboardShortcutsBehaviorTests
         diagram.TriggerKeyDown(new KeyboardEventArgs("A", "A", 0, false, false, false));
 
         // Assert
-        executed.Should().BeFalse();
+        Assert.False(executed);
     }
 
     [Fact]
@@ -83,7 +82,7 @@ public class KeyboardShortcutsBehaviorTests
         diagram.TriggerKeyDown(new KeyboardEventArgs("A", "A", 0, false, false, false));
 
         // Assert
-        executed1.Should().BeFalse();
-        executed2.Should().BeTrue();
+        Assert.False(executed1);
+        Assert.True(executed2);
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Behaviors/KeyboardShortcutsDefaultsTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Behaviors/KeyboardShortcutsDefaultsTests.cs
@@ -1,6 +1,5 @@
 ﻿using Blazor.Diagrams.Core.Behaviors;
 using Blazor.Diagrams.Core.Models;
-using FluentAssertions;
 using System;
 using System.Threading.Tasks;
 using Xunit;
@@ -24,7 +23,7 @@ public class KeyboardShortcutsDefaultsTests
         await KeyboardShortcutsDefaults.DeleteSelection(diagram);
 
         // Assert
-        diagram.Nodes.Count.Should().Be(1);
+        Assert.Equal(1, diagram.Nodes.Count);
     }
 
     [Fact]
@@ -47,8 +46,8 @@ public class KeyboardShortcutsDefaultsTests
         await KeyboardShortcutsDefaults.DeleteSelection(diagram);
 
         // Assert
-        funcCalled.Should().BeTrue();
-        diagram.Groups.Count.Should().Be(1);
+        Assert.True(funcCalled);
+        Assert.Equal(1, diagram.Groups.Count);
     }
 
     [Fact]
@@ -71,8 +70,8 @@ public class KeyboardShortcutsDefaultsTests
         await KeyboardShortcutsDefaults.DeleteSelection(diagram);
 
         // Assert
-        funcCalled.Should().BeTrue();
-        diagram.Nodes.Count.Should().Be(1);
+        Assert.True(funcCalled);                  
+        Assert.Equal(1, diagram.Nodes.Count);
     }
 
     [Fact]
@@ -100,8 +99,8 @@ public class KeyboardShortcutsDefaultsTests
         await KeyboardShortcutsDefaults.DeleteSelection(diagram);
 
         // Assert
-        funcCalled.Should().BeTrue();
-        diagram.Links.Count.Should().Be(1);
+        Assert.True(funcCalled);                  
+        Assert.Equal(1, diagram.Links.Count);
     }
 
     [Fact]
@@ -126,8 +125,8 @@ public class KeyboardShortcutsDefaultsTests
         await KeyboardShortcutsDefaults.DeleteSelection(diagram);
 
         // Assert
-        diagram.Nodes.Count.Should().Be(0);
-        diagram.Links.Count.Should().Be(0);
-        refreshes.Should().Be(1);
+        Assert.Equal(0, diagram.Nodes.Count);    
+        Assert.Equal(0, diagram.Links.Count);    
+        Assert.Equal(1, refreshes);
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Behaviors/KeyboardShortcutsDefaultsTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Behaviors/KeyboardShortcutsDefaultsTests.cs
@@ -21,7 +21,7 @@ public class KeyboardShortcutsDefaultsTests
         await KeyboardShortcutsDefaults.DeleteSelection(diagram);
 
         // Assert
-        Assert.Equal(1, diagram.Nodes.Count);
+        Assert.Single(diagram.Nodes);
     }
 
     [Fact]
@@ -45,7 +45,7 @@ public class KeyboardShortcutsDefaultsTests
 
         // Assert
         Assert.True(funcCalled);
-        Assert.Equal(1, diagram.Groups.Count);
+        Assert.Single(diagram.Groups);
     }
 
     [Fact]
@@ -69,7 +69,7 @@ public class KeyboardShortcutsDefaultsTests
 
         // Assert
         Assert.True(funcCalled);
-        Assert.Equal(1, diagram.Nodes.Count);
+        Assert.Single(diagram.Nodes);
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public class KeyboardShortcutsDefaultsTests
 
         // Assert
         Assert.True(funcCalled);
-        Assert.Equal(1, diagram.Links.Count);
+        Assert.Single(diagram.Links);
     }
 
     [Fact]
@@ -123,8 +123,8 @@ public class KeyboardShortcutsDefaultsTests
         await KeyboardShortcutsDefaults.DeleteSelection(diagram);
 
         // Assert
-        Assert.Equal(0, diagram.Nodes.Count);
-        Assert.Equal(0, diagram.Links.Count);
+        Assert.Empty(diagram.Nodes);
+        Assert.Empty(diagram.Links);
         Assert.Equal(1, refreshes);
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Behaviors/KeyboardShortcutsDefaultsTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Behaviors/KeyboardShortcutsDefaultsTests.cs
@@ -1,7 +1,5 @@
 ﻿using Blazor.Diagrams.Core.Behaviors;
 using Blazor.Diagrams.Core.Models;
-using System;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Blazor.Diagrams.Core.Tests.Behaviors;
@@ -70,7 +68,7 @@ public class KeyboardShortcutsDefaultsTests
         await KeyboardShortcutsDefaults.DeleteSelection(diagram);
 
         // Assert
-        Assert.True(funcCalled);                  
+        Assert.True(funcCalled);
         Assert.Equal(1, diagram.Nodes.Count);
     }
 
@@ -99,7 +97,7 @@ public class KeyboardShortcutsDefaultsTests
         await KeyboardShortcutsDefaults.DeleteSelection(diagram);
 
         // Assert
-        Assert.True(funcCalled);                  
+        Assert.True(funcCalled);
         Assert.Equal(1, diagram.Links.Count);
     }
 
@@ -125,8 +123,8 @@ public class KeyboardShortcutsDefaultsTests
         await KeyboardShortcutsDefaults.DeleteSelection(diagram);
 
         // Assert
-        Assert.Equal(0, diagram.Nodes.Count);    
-        Assert.Equal(0, diagram.Links.Count);    
+        Assert.Equal(0, diagram.Nodes.Count);
+        Assert.Equal(0, diagram.Links.Count);
         Assert.Equal(1, refreshes);
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Blazor.Diagrams.Core.Tests.csproj
+++ b/tests/Blazor.Diagrams.Core.Tests/Blazor.Diagrams.Core.Tests.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="Moq" />

--- a/tests/Blazor.Diagrams.Core.Tests/DiagramOrderingTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/DiagramOrderingTests.cs
@@ -1,5 +1,4 @@
 ﻿using Blazor.Diagrams.Core.Models;
-using System;
 using Xunit;
 
 namespace Blazor.Diagrams.Core.Tests;
@@ -76,8 +75,8 @@ public class DiagramOrderingTests
         node1.Order = 10;
 
         // Assert
-        Assert.Equal(node2, diagram.OrderedSelectables[0]);   
-        Assert.Equal(node1, diagram.OrderedSelectables[1]);  
+        Assert.Equal(node2, diagram.OrderedSelectables[0]);
+        Assert.Equal(node1, diagram.OrderedSelectables[1]);
     }
 
     [Fact]
@@ -94,7 +93,7 @@ public class DiagramOrderingTests
         node1.Order = 10;
 
         // Assert
-        Assert.Equal(1,refreshes);
+        Assert.Equal(1, refreshes);
     }
 
     [Fact]
@@ -110,14 +109,14 @@ public class DiagramOrderingTests
         diagram.SendToBack(node3);
 
         // Assert
-        Assert.Equal(node3, diagram.OrderedSelectables[0]);       
-        Assert.Equal(1, diagram.OrderedSelectables[0].Order);      
+        Assert.Equal(node3, diagram.OrderedSelectables[0]);
+        Assert.Equal(1, diagram.OrderedSelectables[0].Order);
 
-        Assert.Equal(node1, diagram.OrderedSelectables[1]);       
-        Assert.Equal(2, diagram.OrderedSelectables[1].Order);      
+        Assert.Equal(node1, diagram.OrderedSelectables[1]);
+        Assert.Equal(2, diagram.OrderedSelectables[1].Order);
 
-        Assert.Equal(node2, diagram.OrderedSelectables[2]);      
-        Assert.Equal(3, diagram.OrderedSelectables[2].Order); 
+        Assert.Equal(node2, diagram.OrderedSelectables[2]);
+        Assert.Equal(3, diagram.OrderedSelectables[2].Order);
     }
 
     [Fact]
@@ -133,14 +132,14 @@ public class DiagramOrderingTests
         diagram.SendToFront(node1);
 
         // Assert
-        Assert.Equal(node2, diagram.OrderedSelectables[0]);       
-        Assert.Equal(2, diagram.OrderedSelectables[0].Order);      
+        Assert.Equal(node2, diagram.OrderedSelectables[0]);
+        Assert.Equal(2, diagram.OrderedSelectables[0].Order);
 
-        Assert.Equal(node3, diagram.OrderedSelectables[1]);       
-        Assert.Equal(3, diagram.OrderedSelectables[1].Order);      
+        Assert.Equal(node3, diagram.OrderedSelectables[1]);
+        Assert.Equal(3, diagram.OrderedSelectables[1].Order);
 
-        Assert.Equal(node1, diagram.OrderedSelectables[2]);       
-        Assert.Equal(4, diagram.OrderedSelectables[2].Order);    
+        Assert.Equal(node1, diagram.OrderedSelectables[2]);
+        Assert.Equal(4, diagram.OrderedSelectables[2].Order);
     }
 
     [Fact]
@@ -174,8 +173,8 @@ public class DiagramOrderingTests
         node1.Order = 10;
 
         // Assert
-        Assert.Equal(node1, diagram.OrderedSelectables[0]); 
-        Assert.Equal(node2, diagram.OrderedSelectables[1]);  
+        Assert.Equal(node1, diagram.OrderedSelectables[0]);
+        Assert.Equal(node2, diagram.OrderedSelectables[1]);
     }
 
     [Fact]
@@ -190,7 +189,7 @@ public class DiagramOrderingTests
         diagram.RefreshOrders();
 
         // Assert
-        Assert.Equal(node2, diagram.OrderedSelectables[0]); 
-        Assert.Equal(node1, diagram.OrderedSelectables[1]);  
+        Assert.Equal(node2, diagram.OrderedSelectables[0]);
+        Assert.Equal(node1, diagram.OrderedSelectables[1]);
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/DiagramOrderingTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/DiagramOrderingTests.cs
@@ -1,5 +1,4 @@
 ﻿using Blazor.Diagrams.Core.Models;
-using FluentAssertions;
 using System;
 using Xunit;
 
@@ -17,7 +16,7 @@ public class DiagramOrderingTests
         var minOrder = diagram.GetMinOrder();
 
         // Assert
-        minOrder.Should().Be(0);
+        Assert.Equal(0, minOrder);
     }
 
     [Fact]
@@ -33,7 +32,7 @@ public class DiagramOrderingTests
         var minOrder = diagram.GetMinOrder();
 
         // Assert
-        minOrder.Should().Be(1);
+        Assert.Equal(1, minOrder);
     }
 
     [Fact]
@@ -46,7 +45,7 @@ public class DiagramOrderingTests
         var maxOrder = diagram.GetMaxOrder();
 
         // Assert
-        maxOrder.Should().Be(0);
+        Assert.Equal(0, maxOrder);
     }
 
     [Fact]
@@ -62,7 +61,7 @@ public class DiagramOrderingTests
         var maxOrder = diagram.GetMaxOrder();
 
         // Assert
-        maxOrder.Should().Be(3);
+        Assert.Equal(3, maxOrder);
     }
 
     [Fact]
@@ -77,8 +76,8 @@ public class DiagramOrderingTests
         node1.Order = 10;
 
         // Assert
-        diagram.OrderedSelectables[0].Should().Be(node2);
-        diagram.OrderedSelectables[1].Should().Be(node1);
+        Assert.Equal(node2, diagram.OrderedSelectables[0]);   
+        Assert.Equal(node1, diagram.OrderedSelectables[1]);  
     }
 
     [Fact]
@@ -95,7 +94,7 @@ public class DiagramOrderingTests
         node1.Order = 10;
 
         // Assert
-        refreshes.Should().Be(1);
+        Assert.Equal(1,refreshes);
     }
 
     [Fact]
@@ -111,14 +110,14 @@ public class DiagramOrderingTests
         diagram.SendToBack(node3);
 
         // Assert
-        diagram.OrderedSelectables[0].Should().Be(node3);
-        diagram.OrderedSelectables[0].Order.Should().Be(1);
+        Assert.Equal(node3, diagram.OrderedSelectables[0]);       
+        Assert.Equal(1, diagram.OrderedSelectables[0].Order);      
 
-        diagram.OrderedSelectables[1].Should().Be(node1);
-        diagram.OrderedSelectables[1].Order.Should().Be(2);
+        Assert.Equal(node1, diagram.OrderedSelectables[1]);       
+        Assert.Equal(2, diagram.OrderedSelectables[1].Order);      
 
-        diagram.OrderedSelectables[2].Should().Be(node2);
-        diagram.OrderedSelectables[2].Order.Should().Be(3);
+        Assert.Equal(node2, diagram.OrderedSelectables[2]);      
+        Assert.Equal(3, diagram.OrderedSelectables[2].Order); 
     }
 
     [Fact]
@@ -134,14 +133,14 @@ public class DiagramOrderingTests
         diagram.SendToFront(node1);
 
         // Assert
-        diagram.OrderedSelectables[0].Should().Be(node2);
-        diagram.OrderedSelectables[0].Order.Should().Be(2);
+        Assert.Equal(node2, diagram.OrderedSelectables[0]);       
+        Assert.Equal(2, diagram.OrderedSelectables[0].Order);      
 
-        diagram.OrderedSelectables[1].Should().Be(node3);
-        diagram.OrderedSelectables[1].Order.Should().Be(3);
+        Assert.Equal(node3, diagram.OrderedSelectables[1]);       
+        Assert.Equal(3, diagram.OrderedSelectables[1].Order);      
 
-        diagram.OrderedSelectables[2].Should().Be(node1);
-        diagram.OrderedSelectables[2].Order.Should().Be(4);
+        Assert.Equal(node1, diagram.OrderedSelectables[2]);       
+        Assert.Equal(4, diagram.OrderedSelectables[2].Order);    
     }
 
     [Fact]
@@ -159,7 +158,7 @@ public class DiagramOrderingTests
         diagram.Nodes.Remove(node1);
 
         // Assert
-        refreshes.Should().Be(1);
+        Assert.Equal(1, refreshes);
     }
 
     [Fact]
@@ -175,8 +174,8 @@ public class DiagramOrderingTests
         node1.Order = 10;
 
         // Assert
-        diagram.OrderedSelectables[0].Should().Be(node1);
-        diagram.OrderedSelectables[1].Should().Be(node2);
+        Assert.Equal(node1, diagram.OrderedSelectables[0]); 
+        Assert.Equal(node2, diagram.OrderedSelectables[1]);  
     }
 
     [Fact]
@@ -191,7 +190,7 @@ public class DiagramOrderingTests
         diagram.RefreshOrders();
 
         // Assert
-        diagram.OrderedSelectables[0].Should().Be(node2);
-        diagram.OrderedSelectables[1].Should().Be(node1);
+        Assert.Equal(node2, diagram.OrderedSelectables[0]); 
+        Assert.Equal(node1, diagram.OrderedSelectables[1]);  
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/DiagramTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/DiagramTests.cs
@@ -1,6 +1,5 @@
 ﻿using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Core.Models;
-using System;
 using Xunit;
 
 namespace Blazor.Diagrams.Core.Tests;
@@ -20,8 +19,8 @@ public class DiagramTests
         var pt = diagram.GetScreenPoint(100, 200);
 
         // Assert
-        Assert.Equal(203.4,pt.X);
-        Assert.Equal(361.8, pt.Y);
+        Assert.Equal(203.4, pt.X);// 2*X + panX + left
+        Assert.Equal(361.8, pt.Y);// 2*Y + panY + top
     }
 
     [Fact]
@@ -40,10 +39,10 @@ public class DiagramTests
         diagram.ZoomToFit(10);
 
         // Assert
-        Assert.InRange(diagram.Zoom, 7.679, 7.681);  
-        Assert.Equal(-307.2, diagram.Pan.X);         
-        Assert.Equal(-307.2, diagram.Pan.Y);         
-        }
+        Assert.InRange(diagram.Zoom, 7.679, 7.681);
+        Assert.Equal(-307.2, diagram.Pan.X);
+        Assert.Equal(-307.2, diagram.Pan.Y);
+    }
 
     [Fact]
     public void ZoomToFit_ShouldUseNodesWhenNoneSelected()
@@ -60,9 +59,9 @@ public class DiagramTests
         diagram.ZoomToFit(10);
 
         // Assert
-        Assert.InRange(diagram.Zoom, 7.679, 7.681);  
-        Assert.Equal(-307.2, diagram.Pan.X);         
-        Assert.Equal(-307.2, diagram.Pan.Y);         
+        Assert.InRange(diagram.Zoom, 7.679, 7.681);
+        Assert.Equal(-307.2, diagram.Pan.X);
+        Assert.Equal(-307.2, diagram.Pan.Y);
     }
 
     [Fact]
@@ -87,9 +86,9 @@ public class DiagramTests
         diagram.ZoomToFit(10);
 
         // Assert
-        Assert.Equal(1,refreshes);
-        Assert.Equal(1,zoomChanges);
-        Assert.Equal(1,panChanges);
+        Assert.Equal(1, refreshes);
+        Assert.Equal(1, zoomChanges);
+        Assert.Equal(1, panChanges);
     }
 
     [Theory]

--- a/tests/Blazor.Diagrams.Core.Tests/DiagramTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/DiagramTests.cs
@@ -1,6 +1,5 @@
 ﻿using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Core.Models;
-using FluentAssertions;
 using System;
 using Xunit;
 
@@ -21,8 +20,8 @@ public class DiagramTests
         var pt = diagram.GetScreenPoint(100, 200);
 
         // Assert
-        pt.X.Should().Be(203.4); // 2*X + panX + left
-        pt.Y.Should().Be(361.8); // 2*Y + panY + top
+        Assert.Equal(203.4,pt.X);
+        Assert.Equal(361.8, pt.Y);
     }
 
     [Fact]
@@ -41,10 +40,10 @@ public class DiagramTests
         diagram.ZoomToFit(10);
 
         // Assert
-        diagram.Zoom.Should().BeApproximately(7.68, 0.001);
-        diagram.Pan.X.Should().Be(-307.2);
-        diagram.Pan.Y.Should().Be(-307.2);
-    }
+        Assert.InRange(diagram.Zoom, 7.679, 7.681);  
+        Assert.Equal(-307.2, diagram.Pan.X);         
+        Assert.Equal(-307.2, diagram.Pan.Y);         
+        }
 
     [Fact]
     public void ZoomToFit_ShouldUseNodesWhenNoneSelected()
@@ -61,9 +60,9 @@ public class DiagramTests
         diagram.ZoomToFit(10);
 
         // Assert
-        diagram.Zoom.Should().BeApproximately(7.68, 0.001);
-        diagram.Pan.X.Should().Be(-307.2);
-        diagram.Pan.Y.Should().Be(-307.2);
+        Assert.InRange(diagram.Zoom, 7.679, 7.681);  
+        Assert.Equal(-307.2, diagram.Pan.X);         
+        Assert.Equal(-307.2, diagram.Pan.Y);         
     }
 
     [Fact]
@@ -88,9 +87,9 @@ public class DiagramTests
         diagram.ZoomToFit(10);
 
         // Assert
-        refreshes.Should().Be(1);
-        zoomChanges.Should().Be(1);
-        panChanges.Should().Be(1);
+        Assert.Equal(1,refreshes);
+        Assert.Equal(1,zoomChanges);
+        Assert.Equal(1,panChanges);
     }
 
     [Theory]
@@ -133,6 +132,6 @@ public class DiagramTests
         var exception = Record.Exception(() => diagram.SetContainer(null));
 
         // Assert
-        exception.Should().BeNull();
+        Assert.Null(exception);
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Geometry/PointTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Geometry/PointTests.cs
@@ -1,7 +1,5 @@
 ﻿using Blazor.Diagrams.Core.Geometry;
-using FluentAssertions;
 using Xunit;
-
 namespace Blazor.Diagrams.Core.Tests.Geometry;
 
 public class PointTests
@@ -15,6 +13,6 @@ public class PointTests
     {
         var pt1 = new Point(x1, y1);
         var pt2 = new Point(x2, y2);
-        pt1.DistanceTo(pt2).Should().BeApproximately(expected, 0.0001);
+        Assert.InRange(pt1.DistanceTo(pt2), expected - 0.0001, expected + 0.0001);
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Layers/GroupLayerTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Layers/GroupLayerTests.cs
@@ -1,5 +1,4 @@
 ﻿using Blazor.Diagrams.Core.Models;
-using FluentAssertions;
 using System;
 using Xunit;
 
@@ -24,7 +23,7 @@ public class GroupLayerTests
         diagram.Groups.Group(Array.Empty<NodeModel>());
 
         // Assert
-        factoryCalled.Should().BeTrue();
+        Assert.True(factoryCalled);
     }
 
     [Fact]
@@ -42,7 +41,7 @@ public class GroupLayerTests
         diagram.Groups.Remove(group);
 
         // Assert
-        diagram.Links.Should().BeEmpty();
+        Assert.Empty(diagram.Links);
     }
 
     [Fact]
@@ -58,7 +57,7 @@ public class GroupLayerTests
         diagram.Groups.Remove(group);
 
         // Assert
-        diagram.Links.Should().BeEmpty();
+        Assert.Empty(diagram.Links);
     }
 
     [Fact]
@@ -73,8 +72,8 @@ public class GroupLayerTests
         diagram.Groups.Remove(group1);
 
         // Assert
-        group2.Children.Should().BeEmpty();
-        group1.Group.Should().BeNull();
+        Assert.Empty(group2.Children);
+        Assert.Null(group1.Group);
     }
 
     [Fact]
@@ -89,8 +88,8 @@ public class GroupLayerTests
         diagram.Groups.Remove(group);
 
         // Assert
-        group.Children.Should().BeEmpty();
-        node.Group.Should().BeNull();
+        Assert.Empty(group.Children);
+        Assert.Null(node.Group);
     }
 
     [Fact]
@@ -105,7 +104,7 @@ public class GroupLayerTests
         diagram.Groups.Delete(group2);
 
         // Assert
-        diagram.Groups.Should().BeEmpty();
+        Assert.Empty(diagram.Groups);
     }
 
     [Fact]
@@ -120,8 +119,8 @@ public class GroupLayerTests
         diagram.Groups.Delete(group);
 
         // Assert
-        diagram.Groups.Should().BeEmpty();
-        diagram.Nodes.Should().BeEmpty();
+        Assert.Empty(diagram.Groups);
+        Assert.Empty(diagram.Nodes);
     }
 
     [Fact]
@@ -136,7 +135,7 @@ public class GroupLayerTests
         var group = diagram.Groups.Add(new GroupModel(Array.Empty<NodeModel>()));
 
         // Assert
-        refreshes.Should().Be(1);
+        Assert.Equal(1, refreshes);
     }
 
     [Fact]
@@ -152,7 +151,7 @@ public class GroupLayerTests
         diagram.Groups.Remove(group);
 
         // Assert
-        refreshes.Should().Be(1);
+        Assert.Equal(1,refreshes);
     }
 
     [Fact]
@@ -169,6 +168,6 @@ public class GroupLayerTests
         diagram.Groups.Delete(group);
 
         // Assert
-        refreshes.Should().Be(1);
+        Assert.Equal(1,refreshes);
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Layers/NodeLayerTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Layers/NodeLayerTests.cs
@@ -1,5 +1,4 @@
 ﻿using Blazor.Diagrams.Core.Models;
-using FluentAssertions;
 using Xunit;
 
 namespace Blazor.Diagrams.Core.Tests.Layers;
@@ -21,7 +20,7 @@ public class NodeLayerTests
         diagram.Nodes.Remove(node1);
 
         // Assert
-        diagram.Links.Should().BeEmpty();
+        Assert.Empty(diagram.Links);
     }
 
     [Fact]
@@ -37,7 +36,7 @@ public class NodeLayerTests
         diagram.Nodes.Remove(node1);
 
         // Assert
-        diagram.Links.Should().BeEmpty();
+        Assert.Empty(diagram.Links);
     }
 
     [Fact]
@@ -52,8 +51,8 @@ public class NodeLayerTests
         diagram.Nodes.Remove(node);
 
         // Assert
-        group.Children.Should().BeEmpty();
-        node.Group.Should().BeNull();
+        Assert.Empty(group.Children);
+        Assert.Null(node.Group);
     }
 
     [Fact]
@@ -68,7 +67,7 @@ public class NodeLayerTests
         var node = diagram.Nodes.Add(new NodeModel());
 
         // Assert
-        refreshes.Should().Be(1);
+        Assert.Equal(1,refreshes);
     }
 
     [Fact]
@@ -86,7 +85,7 @@ public class NodeLayerTests
         diagram.Nodes.Remove(node1);
 
         // Assert
-        refreshes.Should().Be(1);
+        Assert.Equal(1,refreshes);
     }
 
     [Fact]
@@ -101,6 +100,6 @@ public class NodeLayerTests
         diagram.Nodes.Remove(node);
 
         // Assert
-        diagram.Controls.GetFor(node).Should().BeNull();
+        Assert.Null(diagram.Controls.GetFor(node));
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Models/Base/BaseLinkModelTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Models/Base/BaseLinkModelTests.cs
@@ -35,12 +35,12 @@ public class BaseLinkModelTests
         link.SetSource(sp);
 
         // Assert
-        Assert.Equal(1,eventsTriggered);                           
-        Assert.Same(sp,link.Source);                                
-        Assert.NotNull(oldSp);                                       
-        Assert.Same(sp,newSp);                                      
-        Assert.Same(link,linkInstance);                             
-        Assert.Same(port,link.Source.Model);
+        Assert.Equal(1, eventsTriggered);
+        Assert.Same(sp, link.Source);
+        Assert.NotNull(oldSp);
+        Assert.Same(sp, newSp);
+        Assert.Same(link, linkInstance);
+        Assert.Same(port, link.Source.Model);
     }
 
     [Fact]
@@ -68,12 +68,12 @@ public class BaseLinkModelTests
         link.SetTarget(tp);
 
         // Assert
-        Assert.Equal(1,eventsTriggered);
-        Assert.Same(tp,link.Target);
+        Assert.Equal(1, eventsTriggered);
+        Assert.Same(tp, link.Target);
         Assert.IsType<PositionAnchor>(oldTp);
-        Assert.Same(tp,newTp);
-        Assert.Same(link,linkInstance);
-        Assert.Same(port,link.Target!.Model);
+        Assert.Same(tp, newTp);
+        Assert.Same(link, linkInstance);
+        Assert.Same(port, link.Target!.Model);
     }
 
     [Fact]
@@ -90,9 +90,9 @@ public class BaseLinkModelTests
         var bounds = link.GetBounds()!;
 
         // Assert
-        Assert.Equal(10,bounds.Left);
-        Assert.Equal(5,bounds.Top);
-        Assert.Equal(90,bounds.Width);
-        Assert.Equal(75,bounds.Height);
+        Assert.Equal(10, bounds.Left);
+        Assert.Equal(5, bounds.Top);
+        Assert.Equal(90, bounds.Width);
+        Assert.Equal(75, bounds.Height);
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Models/Base/BaseLinkModelTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Models/Base/BaseLinkModelTests.cs
@@ -4,7 +4,6 @@ using Blazor.Diagrams.Core.Models;
 using Blazor.Diagrams.Core.Models.Base;
 using Blazor.Diagrams.Core.PathGenerators;
 using Blazor.Diagrams.Core.Routers;
-using FluentAssertions;
 using Xunit;
 
 namespace Blazor.Diagrams.Core.Tests.Models.Base;
@@ -36,12 +35,12 @@ public class BaseLinkModelTests
         link.SetSource(sp);
 
         // Assert
-        eventsTriggered.Should().Be(1);
-        link.Source.Should().BeSameAs(sp);
-        oldSp.Should().NotBeNull();
-        newSp.Should().BeSameAs(sp);
-        linkInstance.Should().BeSameAs(link);
-        link.Source.Model.Should().BeSameAs(port);
+        Assert.Equal(1,eventsTriggered);                           
+        Assert.Same(sp,link.Source);                                
+        Assert.NotNull(oldSp);                                       
+        Assert.Same(sp,newSp);                                      
+        Assert.Same(link,linkInstance);                             
+        Assert.Same(port,link.Source.Model);
     }
 
     [Fact]
@@ -69,12 +68,12 @@ public class BaseLinkModelTests
         link.SetTarget(tp);
 
         // Assert
-        eventsTriggered.Should().Be(1);
-        link.Target.Should().BeSameAs(tp);
-        oldTp.Should().BeOfType<PositionAnchor>();
-        newTp.Should().BeSameAs(tp);
-        linkInstance.Should().BeSameAs(link);
-        link.Target!.Model.Should().BeSameAs(port);
+        Assert.Equal(1,eventsTriggered);
+        Assert.Same(tp,link.Target);
+        Assert.IsType<PositionAnchor>(oldTp);
+        Assert.Same(tp,newTp);
+        Assert.Same(link,linkInstance);
+        Assert.Same(port,link.Target!.Model);
     }
 
     [Fact]
@@ -91,9 +90,9 @@ public class BaseLinkModelTests
         var bounds = link.GetBounds()!;
 
         // Assert
-        bounds.Left.Should().Be(10);
-        bounds.Top.Should().Be(5);
-        bounds.Width.Should().Be(90);
-        bounds.Height.Should().Be(75);
+        Assert.Equal(10,bounds.Left);
+        Assert.Equal(5,bounds.Top);
+        Assert.Equal(90,bounds.Width);
+        Assert.Equal(75,bounds.Height);
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Positions/Resizing/BottomLeftResizerProviderTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Positions/Resizing/BottomLeftResizerProviderTests.cs
@@ -23,10 +23,10 @@ public class BottomLeftResizerProviderTests
         diagram.SelectModel(node, false);
 
         // before resize
-        Assert.Equal(0, node.Position.X);       
-        Assert.Equal(0, node.Position.Y);      
-        Assert.Equal(100, node.Size.Width);     
-        Assert.Equal(200, node.Size.Height); 
+        Assert.Equal(0, node.Position.X);
+        Assert.Equal(0, node.Position.Y);
+        Assert.Equal(100, node.Size.Width);
+        Assert.Equal(200, node.Size.Height);
 
 
         // resize
@@ -36,10 +36,10 @@ public class BottomLeftResizerProviderTests
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        Assert.Equal(10, node.Position.X);       
-        Assert.Equal(0, node.Position.Y);        
-        Assert.Equal(90, node.Size.Width);       
-        Assert.Equal(215, node.Size.Height);     
+        Assert.Equal(10, node.Position.X);
+        Assert.Equal(0, node.Position.Y);
+        Assert.Equal(90, node.Size.Width);
+        Assert.Equal(215, node.Size.Height);
     }
 
     [Fact]

--- a/tests/Blazor.Diagrams.Core.Tests/Positions/Resizing/BottomLeftResizerProviderTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Positions/Resizing/BottomLeftResizerProviderTests.cs
@@ -4,7 +4,6 @@ using Blazor.Diagrams.Core.Events;
 using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Core.Models;
 using Blazor.Diagrams.Core.Positions.Resizing;
-using FluentAssertions;
 using Xunit;
 
 namespace Blazor.Diagrams.Core.Tests.Positions.Resizing;
@@ -24,10 +23,11 @@ public class BottomLeftResizerProviderTests
         diagram.SelectModel(node, false);
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        Assert.Equal(0, node.Position.X);       
+        Assert.Equal(0, node.Position.Y);      
+        Assert.Equal(100, node.Size.Width);     
+        Assert.Equal(200, node.Size.Height); 
+
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -36,10 +36,10 @@ public class BottomLeftResizerProviderTests
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(10);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(90);
-        node.Size.Height.Should().Be(215);
+        Assert.Equal(10, node.Position.X);       
+        Assert.Equal(0, node.Position.Y);        
+        Assert.Equal(90, node.Size.Width);       
+        Assert.Equal(215, node.Size.Height);     
     }
 
     [Fact]
@@ -56,10 +56,10 @@ public class BottomLeftResizerProviderTests
         diagram.BehaviorOptions.DiagramWheelBehavior = diagram.GetBehavior<ScrollBehavior>();
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        Assert.Equal(0, node.Position.X);
+        Assert.Equal(0, node.Position.Y);
+        Assert.Equal(100, node.Size.Width);
+        Assert.Equal(200, node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -68,10 +68,10 @@ public class BottomLeftResizerProviderTests
 
 
         // after resize
-        node.Position.X.Should().Be(10);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(90);
-        node.Size.Height.Should().Be(300);
+        Assert.Equal(10, node.Position.X);
+        Assert.Equal(0, node.Position.Y);
+        Assert.Equal(90, node.Size.Width);
+        Assert.Equal(300, node.Size.Height);
     }
 
     [Fact]
@@ -88,10 +88,10 @@ public class BottomLeftResizerProviderTests
         diagram.SelectModel(node, false);
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(300);
-        node.Size.Height.Should().Be(300);
+        Assert.Equal(0, node.Position.X);
+        Assert.Equal(0, node.Position.Y);
+        Assert.Equal(300, node.Size.Width);
+        Assert.Equal(300, node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 300, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -102,10 +102,10 @@ public class BottomLeftResizerProviderTests
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(250);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(50);
-        node.Size.Height.Should().Be(100);
+        Assert.Equal(250, node.Position.X);
+        Assert.Equal(0, node.Position.Y);
+        Assert.Equal(50, node.Size.Width);
+        Assert.Equal(100, node.Size.Height);
     }
 
     [Fact]
@@ -122,10 +122,10 @@ public class BottomLeftResizerProviderTests
         diagram.SetZoom(0.5);
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        Assert.Equal(0, node.Position.X);
+        Assert.Equal(0, node.Position.Y);
+        Assert.Equal(100, node.Size.Width);
+        Assert.Equal(200, node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -134,10 +134,10 @@ public class BottomLeftResizerProviderTests
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(20);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(80);
-        node.Size.Height.Should().Be(230);
+        Assert.Equal(20, node.Position.X);
+        Assert.Equal(0, node.Position.Y);
+        Assert.Equal(80, node.Size.Width);
+        Assert.Equal(230, node.Size.Height);
     }
 
     [Fact]
@@ -154,10 +154,10 @@ public class BottomLeftResizerProviderTests
         diagram.SetZoom(2);
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        Assert.Equal(0, node.Position.X);
+        Assert.Equal(0, node.Position.Y);
+        Assert.Equal(100, node.Size.Width);
+        Assert.Equal(200, node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -166,9 +166,9 @@ public class BottomLeftResizerProviderTests
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(5);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(95);
-        node.Size.Height.Should().Be(207.5);
+        Assert.Equal(5, node.Position.X);
+        Assert.Equal(0, node.Position.Y);
+        Assert.Equal(95, node.Size.Width);
+        Assert.Equal(207.5, node.Size.Height);
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Positions/Resizing/BottomRightResizerProviderTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Positions/Resizing/BottomRightResizerProviderTests.cs
@@ -4,7 +4,6 @@ using Blazor.Diagrams.Core.Events;
 using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Core.Models;
 using Blazor.Diagrams.Core.Positions.Resizing;
-using FluentAssertions;
 using Xunit;
 
 namespace Blazor.Diagrams.Core.Tests.Positions.Resizing;
@@ -24,10 +23,10 @@ public class BottomRightResizerProviderTests
         diagram.SelectModel(node, false);
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(100,node.Size.Width);
+        Assert.Equal(200,node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -36,10 +35,10 @@ public class BottomRightResizerProviderTests
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(110);
-        node.Size.Height.Should().Be(215);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(110,node.Size.Width);
+        Assert.Equal(215,node.Size.Height);
     }
 
     [Fact]
@@ -57,10 +56,10 @@ public class BottomRightResizerProviderTests
 
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(100,node.Size.Width);
+        Assert.Equal(200,node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -69,10 +68,10 @@ public class BottomRightResizerProviderTests
 
 
         // after resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(110);
-        node.Size.Height.Should().Be(300);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(110,node.Size.Width);
+        Assert.Equal(300,node.Size.Height);
     }
 
     [Fact]
@@ -88,10 +87,10 @@ public class BottomRightResizerProviderTests
         diagram.SelectModel(node, false);
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(100,node.Size.Width);
+        Assert.Equal(200,node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -100,10 +99,10 @@ public class BottomRightResizerProviderTests
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(0);
-        node.Size.Height.Should().Be(0);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(0,node.Size.Width);
+        Assert.Equal(0,node.Size.Height);
     }
 
     [Fact]
@@ -120,10 +119,10 @@ public class BottomRightResizerProviderTests
         diagram.SetZoom(0.5);
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(100,node.Size.Width);
+        Assert.Equal(200,node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -132,10 +131,10 @@ public class BottomRightResizerProviderTests
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(120);
-        node.Size.Height.Should().Be(230);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(120,node.Size.Width);
+        Assert.Equal(230,node.Size.Height);
     }
 
     [Fact]
@@ -152,10 +151,10 @@ public class BottomRightResizerProviderTests
         diagram.SetZoom(2);
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(100,node.Size.Width);
+        Assert.Equal(200,node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -164,9 +163,9 @@ public class BottomRightResizerProviderTests
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(105);
-        node.Size.Height.Should().Be(207.5);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(105,node.Size.Width);
+        Assert.Equal(207.5,node.Size.Height);
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Positions/Resizing/TopLeftResizerProviderTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Positions/Resizing/TopLeftResizerProviderTests.cs
@@ -4,7 +4,6 @@ using Blazor.Diagrams.Core.Events;
 using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Core.Models;
 using Blazor.Diagrams.Core.Positions.Resizing;
-using FluentAssertions;
 using Xunit;
 
 namespace Blazor.Diagrams.Core.Tests.Positions.Resizing;
@@ -24,10 +23,10 @@ public class TopLeftResizerProviderTests
         diagram.SelectModel(node, false);
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(100,node.Size.Width);
+        Assert.Equal(200,node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -36,10 +35,10 @@ public class TopLeftResizerProviderTests
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(10);
-        node.Position.Y.Should().Be(15);
-        node.Size.Width.Should().Be(90);
-        node.Size.Height.Should().Be(185);
+        Assert.Equal(10,node.Position.X);
+        Assert.Equal(15,node.Position.Y);
+        Assert.Equal(90,node.Size.Width);
+        Assert.Equal(185,node.Size.Height);
     }
 
     [Fact]
@@ -57,10 +56,10 @@ public class TopLeftResizerProviderTests
 
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(100,node.Size.Width);
+        Assert.Equal(200,node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -69,10 +68,10 @@ public class TopLeftResizerProviderTests
 
 
         // after resize
-        node.Position.X.Should().Be(10);
-        node.Position.Y.Should().Be(-100);
-        node.Size.Width.Should().Be(90);
-        node.Size.Height.Should().Be(300);
+        Assert.Equal(10,node.Position.X);
+        Assert.Equal(-100,node.Position.Y);
+        Assert.Equal(90,node.Size.Width);
+        Assert.Equal(300,node.Size.Height);
     }
 
     [Fact]
@@ -89,10 +88,10 @@ public class TopLeftResizerProviderTests
         diagram.SelectModel(node, false);
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(300);
-        node.Size.Height.Should().Be(300);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(300,node.Size.Width);
+        Assert.Equal(300,node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -103,10 +102,10 @@ public class TopLeftResizerProviderTests
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(250);
-        node.Position.Y.Should().Be(200);
-        node.Size.Width.Should().Be(50);
-        node.Size.Height.Should().Be(100);
+        Assert.Equal(250,node.Position.X);
+        Assert.Equal(200,node.Position.Y);
+        Assert.Equal(50,node.Size.Width);
+        Assert.Equal(100,node.Size.Height);
     }
 
     [Fact]
@@ -123,10 +122,10 @@ public class TopLeftResizerProviderTests
         diagram.SetZoom(0.5);
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(100,node.Size.Width);
+        Assert.Equal(200,node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -135,10 +134,10 @@ public class TopLeftResizerProviderTests
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(20);
-        node.Position.Y.Should().Be(30);
-        node.Size.Width.Should().Be(80);
-        node.Size.Height.Should().Be(170);
+        Assert.Equal(20,node.Position.X);
+        Assert.Equal(30,node.Position.Y);
+        Assert.Equal(80,node.Size.Width);
+        Assert.Equal(170,node.Size.Height);
     }
 
     [Fact]
@@ -155,10 +154,10 @@ public class TopLeftResizerProviderTests
         diagram.SetZoom(2);
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(100,node.Size.Width);
+        Assert.Equal(200,node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -167,9 +166,9 @@ public class TopLeftResizerProviderTests
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(5);
-        node.Position.Y.Should().Be(7.5);
-        node.Size.Width.Should().Be(95);
-        node.Size.Height.Should().Be(192.5);
+        Assert.Equal(5,node.Position.X);
+        Assert.Equal(7.5,node.Position.Y);
+        Assert.Equal(95,node.Size.Width);
+        Assert.Equal(192.5,node.Size.Height);
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Positions/Resizing/TopRightResizerProviderTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Positions/Resizing/TopRightResizerProviderTests.cs
@@ -4,7 +4,6 @@ using Blazor.Diagrams.Core.Events;
 using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Core.Models;
 using Blazor.Diagrams.Core.Positions.Resizing;
-using FluentAssertions;
 using Xunit;
 
 namespace Blazor.Diagrams.Core.Tests.Positions.Resizing;
@@ -24,10 +23,10 @@ public class TopRightResizerProviderTests
         diagram.SelectModel(node, false);
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(100,node.Size.Width);
+        Assert.Equal(200,node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -36,10 +35,10 @@ public class TopRightResizerProviderTests
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(15);
-        node.Size.Width.Should().Be(110);
-        node.Size.Height.Should().Be(185);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(15,node.Position.Y);
+        Assert.Equal(110,node.Size.Width);
+        Assert.Equal(185,node.Size.Height);
     }
 
     [Fact]
@@ -56,10 +55,10 @@ public class TopRightResizerProviderTests
         diagram.BehaviorOptions.DiagramWheelBehavior = diagram.GetBehavior<ScrollBehavior>();
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(100,node.Size.Width);
+        Assert.Equal(200,node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -67,10 +66,10 @@ public class TopRightResizerProviderTests
         diagram.TriggerWheel(new WheelEventArgs(100, 100, 0, 0, false, false, false, 10, -100, 0, 0));
 
         // after resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(-100);
-        node.Size.Width.Should().Be(110);
-        node.Size.Height.Should().Be(300);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(-100,node.Position.Y);
+        Assert.Equal(110,node.Size.Width);
+        Assert.Equal(300,node.Size.Height);
     }
 
     [Fact]
@@ -87,10 +86,10 @@ public class TopRightResizerProviderTests
         diagram.SelectModel(node, false);
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(300);
-        node.Size.Height.Should().Be(300);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(300,node.Size.Width);
+        Assert.Equal(300,node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(300, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -101,10 +100,10 @@ public class TopRightResizerProviderTests
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(200);
-        node.Size.Width.Should().Be(50);
-        node.Size.Height.Should().Be(100);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(200,node.Position.Y);
+        Assert.Equal(50,node.Size.Width);
+        Assert.Equal(100,node.Size.Height);
     }
 
     [Fact]
@@ -121,10 +120,10 @@ public class TopRightResizerProviderTests
         diagram.SetZoom(0.5);
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(100,node.Size.Width);
+        Assert.Equal(200,node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -133,10 +132,10 @@ public class TopRightResizerProviderTests
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(30);
-        node.Size.Width.Should().Be(120);
-        node.Size.Height.Should().Be(170);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(30,node.Position.Y);
+        Assert.Equal(120,node.Size.Width);
+        Assert.Equal(170,node.Size.Height);
     }
 
     [Fact]
@@ -153,10 +152,10 @@ public class TopRightResizerProviderTests
         diagram.SetZoom(2);
 
         // before resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(0);
-        node.Size.Width.Should().Be(100);
-        node.Size.Height.Should().Be(200);
+        Assert.Equal(0,node.Position.X);
+        Assert.Equal(0,node.Position.Y);
+        Assert.Equal(100,node.Size.Width);
+        Assert.Equal(200,node.Size.Height);
 
         // resize
         var eventArgs = new PointerEventArgs(0, 0, 0, 0, false, false, false, 1, 1, 1, 1, 1, 1, "arrow", true);
@@ -165,9 +164,9 @@ public class TopRightResizerProviderTests
         diagram.TriggerPointerMove(null, eventArgs);
 
         // after resize
-        node.Position.X.Should().Be(0);
-        node.Position.Y.Should().Be(7.5);
-        node.Size.Width.Should().Be(105);
-        node.Size.Height.Should().Be(192.5);
+        Assert.Equal(0, node.Position.X);
+        Assert.Equal(7.5, node.Position.Y);
+        Assert.Equal(105, node.Size.Width);
+        Assert.Equal(192.5, node.Size.Height);
     }
 }

--- a/tests/Blazor.Diagrams.Core.Tests/Positions/ShapeAnglePositionProviderTests.cs
+++ b/tests/Blazor.Diagrams.Core.Tests/Positions/ShapeAnglePositionProviderTests.cs
@@ -1,7 +1,6 @@
 using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Core.Models;
 using Blazor.Diagrams.Core.Positions;
-using FluentAssertions;
 using Moq;
 using Xunit;
 
@@ -39,7 +38,7 @@ public class ShapeAnglePositionProviderTests
         var position = provider.GetPosition(nodeMock.Object);
 
         // Assert
-        position!.X.Should().Be(105);
-        position.Y.Should().Be(40);
+        Assert.Equal(105, position!.X);
+        Assert.Equal(40, position.Y);
     }
 }

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>


### PR DESCRIPTION
WI0085622-FluentAssertions needs to be removed from the project Blazor.Diagrams.Core.Tests 