### PR TITLE
WI00856226 - FluentAssertions removal from Blazor.Diagrams.Tests 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
+            8.0.x
             6.0.x
-            3.1.x
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Upload packages
       if: matrix.configuration == 'Release'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: package
         path: /home/runner/work/Blazor.Diagrams/Blazor.Diagrams/src/Blazor.Diagrams/bin/Release/*.nupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
       # Upload package as an atrifact to the GitHub action
     - name: Upload packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: package
         path: ${{ env.PACKAGE_PATH }}

--- a/src/Blazor.Diagrams/Blazor.Diagrams.csproj
+++ b/src/Blazor.Diagrams/Blazor.Diagrams.csproj
@@ -20,9 +20,9 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Components" />
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
-        <PacakgeReference Include="Brutal.Dev.StrongNameSigner" PrivateAssets="All" />
+        <PackageReference Include="Brutal.Dev.StrongNameSigner" PrivateAssets="All" />
         <!-- Reference the SvgPathProperties that we already strong name signed -->
-		<PackageReference Include="SvgPathProperties" PrivateAssets="All" />
+        <PackageReference Include="SvgPathProperties" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Blazor.Diagrams/Blazor.Diagrams.csproj
+++ b/src/Blazor.Diagrams/Blazor.Diagrams.csproj
@@ -22,9 +22,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
         <PacakgeReference Include="Brutal.Dev.StrongNameSigner" PrivateAssets="All" />
         <!-- Reference the SvgPathProperties that we already strong name signed -->
-        <Reference Include="SvgPathProperties" PrivateAssets="All">
-          <HintPath>..\..\packages\svgpathproperties\1.1.2\lib\netstandard2.0\SvgPathProperties.dll</HintPath>
-        </Reference>
+		<PackageReference Include="SvgPathProperties" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>

--- a/tests/Blazor.Diagrams.Tests/Blazor.Diagrams.Tests.csproj
+++ b/tests/Blazor.Diagrams.Tests/Blazor.Diagrams.Tests.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="bunit" />
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="Moq" />

--- a/tests/Blazor.Diagrams.Tests/Components/DiagramCursorTests.cs
+++ b/tests/Blazor.Diagrams.Tests/Components/DiagramCursorTests.cs
@@ -2,7 +2,6 @@
 using Blazor.Diagrams.Components;
 using Blazor.Diagrams.Core.Geometry;
 using Bunit;
-using FluentAssertions;
 using Xunit;
 
 namespace Blazor.Diagrams.Core.Tests.Behaviors
@@ -24,7 +23,7 @@ namespace Blazor.Diagrams.Core.Tests.Behaviors
             var diagramCanvas = cut.Find(".diagram-canvas");
 
             // Assert
-            diagramCanvas.ToMarkup().Should().Contain("cursor: grab; cursor: -webkit-grab;");
+            Assert.Contains("cursor: grab; cursor: -webkit-grab;", diagramCanvas.ToMarkup());
         }
 
         [Fact]
@@ -43,7 +42,7 @@ namespace Blazor.Diagrams.Core.Tests.Behaviors
             var canvasStyle = diagramCanvas.GetStyle().CssText;
 
             // Assert
-            canvasStyle.Should().Contain("cursor: default");
+            Assert.Contains("cursor: default", canvasStyle);
         }
     }
 }

--- a/tests/Blazor.Diagrams.Tests/Components/LinkVertexWidgetTests.cs
+++ b/tests/Blazor.Diagrams.Tests/Components/LinkVertexWidgetTests.cs
@@ -3,7 +3,6 @@ using Blazor.Diagrams.Core.Geometry;
 using Blazor.Diagrams.Core.Models;
 using Blazor.Diagrams.Tests.TestComponents;
 using Bunit;
-using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
 using System.Threading.Tasks;
 using Xunit;
@@ -76,9 +75,9 @@ public class LinkVertexWidgetTests
             .Add(n => n.BlazorDiagram, new BlazorDiagram()));
 
         // Assert
-        cut.RenderCount.Should().Be(1);
+        Assert.Equal(1, cut.RenderCount);
         vertex.Refresh();
-        cut.RenderCount.Should().Be(2);
+        Assert.Equal(2, cut.RenderCount);
     }
 
     [Fact]
@@ -104,8 +103,8 @@ public class LinkVertexWidgetTests
         await cut.Find("circle").DoubleClickAsync(new MouseEventArgs());
 
         // Assert
-        link.Vertices.Should().BeEmpty();
-        linkRefreshes.Should().Be(1);
+        Assert.Empty(link.Vertices);
+        Assert.Equal(1,linkRefreshes);
     }
 
     [Fact]

--- a/tests/Blazor.Diagrams.Tests/Components/NodeWidgetTests.cs
+++ b/tests/Blazor.Diagrams.Tests/Components/NodeWidgetTests.cs
@@ -5,7 +5,6 @@ using Blazor.Diagrams.Core.Models;
 
 using Bunit;
 
-using FluentAssertions;
 
 using Xunit;
 
@@ -26,11 +25,11 @@ public class NodeWidgetTests
 
         // Assert
         var content = cut.Find("div.default-node");
-        content.ClassList.Should().ContainSingle();
-        content.ClassList[0].Should().Be("default-node");
-        content.TextContent.Trim().Should().Be("Title");
+        Assert.Single(content.ClassList);
+        Assert.Equal("default-node", content.ClassList[0]);
+        Assert.Equal("Title", content.TextContent.Trim());
 
         var ports = cut.FindComponents<PortRenderer>();
-        ports.Should().BeEmpty();
+        Assert.Empty(ports);
     }
 }

--- a/tests/Blazor.Diagrams.Tests/DiagramTests.cs
+++ b/tests/Blazor.Diagrams.Tests/DiagramTests.cs
@@ -1,7 +1,6 @@
 ﻿using Blazor.Diagrams.Components;
 using Blazor.Diagrams.Core.Models;
 using Blazor.Diagrams.Core.Models.Base;
-using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Xunit;
 
@@ -20,7 +19,7 @@ public class DiagramTests
         var componentType = diagram.GetComponent<NodeModel>();
 
         // Assert
-        componentType.Should().Be(typeof(NodeWidget));
+        Assert.Equal(typeof(NodeWidget), componentType);
     }
 
     [Fact]
@@ -33,7 +32,7 @@ public class DiagramTests
         var componentType = diagram.GetComponent<NodeModel>();
 
         // Assert
-        componentType.Should().BeNull();
+        Assert.Null(componentType);
     }
 
     [Fact]
@@ -47,7 +46,7 @@ public class DiagramTests
         var componentType = diagram.GetComponent<CustomModel>();
 
         // Assert
-        componentType.Should().Be(typeof(NodeWidget));
+        Assert.Equal(typeof(NodeWidget), componentType);
     }
 
     [Fact]
@@ -62,7 +61,7 @@ public class DiagramTests
         var componentType = diagram.GetComponent<CustomModel>();
 
         // Assert
-        componentType.Should().Be(typeof(CustomWidget));
+        Assert.Equal(typeof(CustomWidget), componentType);
     }
 
     [Fact]
@@ -76,7 +75,7 @@ public class DiagramTests
         var componentType = diagram.GetComponent<CustomModel>(false);
 
         // Assert
-        componentType.Should().BeNull();
+        Assert.Null(componentType);
     }
 
     private class CustomModel : Model { }

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>


### PR DESCRIPTION
FluentAssertions needs to be removed from the project Blazor.Diagrams.Tests in https://github.com/WiseTechGlobal/Blazor.Diagrams/blob/master/tests/Blazor.Diagrams.Tests/Blazor.Diagrams.Tests.csproj. Please use standard assertions instead.