### PR TITLE
[Janitor] Update jquery - 20260414-101735

### DIFF
--- a/samples/SharedDemo/wwwroot/plugins/jquery-scrollTo/package-lock.json
+++ b/samples/SharedDemo/wwwroot/plugins/jquery-scrollTo/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "jquery.scrollto",
+  "version": "2.1.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jquery.scrollto",
+      "version": "2.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "jquery": "^4.0.0"
+      }
+    },
+    "node_modules/jquery": {
+      "version": "4.0.0",
+      "resolved": "https://proget.wtg.zone/npm/Registry/jquery/-/jquery-4.0.0.tgz",
+      "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/samples/SharedDemo/wwwroot/plugins/jquery-scrollTo/package.json
+++ b/samples/SharedDemo/wwwroot/plugins/jquery-scrollTo/package.json
@@ -4,15 +4,36 @@
   "description": "Lightweight, cross-browser and highly customizable animated scrolling with jQuery",
   "main": "jquery.scrollTo.js",
   "license": "MIT",
-  "ignore": ["**/.*","demo","tests","CHANGELOG","README.md","composer.json","bower.json"],
-  "dependencies": { "jquery": ">=1.8" },
+  "ignore": [
+    "**/.*",
+    "demo",
+    "tests",
+    "CHANGELOG",
+    "README.md",
+    "composer.json",
+    "bower.json"
+  ],
+  "dependencies": {
+    "jquery": "^4.0.0"
+  },
   "homepage": "https://github.com/flesler/jquery.scrollTo/",
   "docs": "https://github.com/flesler/jquery.scrollTo/",
   "demo": "http://demos.flesler.com/jquery/scrollTo/",
   "bugs": "https://github.com/flesler/jquery.scrollTo/issues",
   "download": "https://github.com/flesler/jquery.scrollTo/releases",
   "repository": "git://github.com/flesler/jquery.scrollTo",
-  "keywords": ["browser","animated","animation","scrolling","scroll","links","anchors","jquery","jquery-plugin", "ecosystem:jquery"],
+  "keywords": [
+    "browser",
+    "animated",
+    "animation",
+    "scrolling",
+    "scroll",
+    "links",
+    "anchors",
+    "jquery",
+    "jquery-plugin",
+    "ecosystem:jquery"
+  ],
   "author": {
     "name": "Ariel Flesler",
     "web": "https://github.com/flesler/"


### PR DESCRIPTION
## Updates Applied

| Package | Manifest | From | To | Transitive |
|---------|----------|------|----|------------|
| jquery | C:\Data\Temp\Janitor22\github.com\WiseTechGlobal\Blazor.Diagrams\samples\SharedDemo\wwwroot\plugins\jquery-scrollTo\package.json | 1.8.0 | 4.0.0 | No |

## Vulnerability Details

| Package | Severity | Advisory |
|---------|----------|----------|
| jquery | MODERATE | [GHSA-2pqj-h3vj-pqgw](https://github.com/advisories/GHSA-2pqj-h3vj-pqgw) |
| jquery | MODERATE | [GHSA-6c3j-c64m-qhgq](https://github.com/advisories/GHSA-6c3j-c64m-qhgq) |
| jquery | MODERATE | [GHSA-gxr4-xjj5-5px2](https://github.com/jquery/jquery/security/advisories/GHSA-gxr4-xjj5-5px2) |
| jquery | MODERATE | [GHSA-jpcq-cgw6-v4j6](https://github.com/jquery/jquery/security/advisories/GHSA-jpcq-cgw6-v4j6) |
| jquery | MODERATE | [GHSA-q4m3-2j7h-f7xw](https://github.com/advisories/GHSA-q4m3-2j7h-f7xw) |
| jquery | MODERATE | [GHSA-rmxg-73gg-4p98](https://github.com/advisories/GHSA-rmxg-73gg-4p98) |