### PR TITLE
[Janitor] Enable Cpm Transitive Pinning - Blazor.Diagrams (.) - 20260416-151806

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,4 +1,8 @@
 <Project>
+  <PropertyGroup>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageVersion Include="SvgPathProperties" Version="1.1.2" />
     <PackageVersion Include="System.Net.Http.Json" Version="8.0.0" />


### PR DESCRIPTION
Enables CPM transitive pinning in **Blazor.Diagrams** at `.`.