### PR TITLE
[Janitor] Update grunt - 20260416-202622

### DIFF
--- a/samples/SharedDemo/wwwroot/plugins/stickyfill/package.json
+++ b/samples/SharedDemo/wwwroot/plugins/stickyfill/package.json
@@ -20,13 +20,12 @@
   "types": "types/index.d.ts",
   "devDependencies": {
     "babel-preset-es2015": "^6.22.0",
-    "grunt": "^1.0.1",
+    "grunt": "^1.3.0",
     "grunt-babel": "^6.0.0",
     "grunt-bump": "^0.8.0",
     "grunt-contrib-uglify": "^2.0.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-shell": "^2.1.0",
     "grunt-wrap": "^0.3.1"
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
## Updates Applied

| Package | Manifest | From | To | Transitive |
|---------|----------|------|----|------------|
| grunt | C:\Data\Temp\Janitor26\github.com\WiseTechGlobal\Blazor.Diagrams\samples\SharedDemo\wwwroot\plugins\stickyfill\package.json | 1.0.1 | 1.3.0 | No |

## Vulnerability Details

| Package | Severity | Advisory |
|---------|----------|----------|
| grunt | MODERATE | [GHSA-j383-35pm-c5h4](https://github.com/advisories/GHSA-j383-35pm-c5h4) |
| grunt | HIGH | [GHSA-m5pj-vjjf-4m3h](https://github.com/advisories/GHSA-m5pj-vjjf-4m3h) |
| grunt | HIGH | [GHSA-rm36-94g8-835r](https://github.com/advisories/GHSA-rm36-94g8-835r) |